### PR TITLE
Update Release Taxonomy

### DIFF
--- a/release-taxonomy.md
+++ b/release-taxonomy.md
@@ -7,7 +7,11 @@ nav_order: 7
 
 # Release Taxonomy
 
-Releases at Hyperledger are done according to the [semver.org](https://semver.org) [taxonomy][^1]. In addition to the semantic versioning scheme, where we use MAJOR.MINOR.PATCH numbering, following the established guidance given in the semver specification, it is also strongly encouraged that projects should use the following tags, as permitted by semver:
+Releases at Hyperledger can be done either according to [SemVer](#SemVer) or via a release taxonomy that [each project may define](#ProjectDefined).  A project that does not define a release taxonomy must use the SemVer release taxonomy.
+
+## SemVer
+
+Projects using SemVer follow the system outlined at [semver.org](https://semver.org) [taxonomy][^1]. In addition to the semantic versioning scheme, where we use MAJOR.MINOR.PATCH numbering, following the established guidance given in the semver specification, it is also strongly encouraged that projects should use the following tags, as permitted by semver:
 
 * [preview](#preview)
 * [alpha](#alpha)
@@ -15,21 +19,30 @@ Releases at Hyperledger are done according to the [semver.org](https://semver.or
 * [rcN](#rcn) (release candidate N - where N is 1-n incremented for each candidate)
 * snapshot-&lt;sha&gt;[^2] for interim, possible unstable builds
 
-## preview
+### preview
 
 Not feature complete, but most functionality is implemented. Any missing functionality that is committed to the production release is identified, and there are specific people working on those features. Not heavily performance tuned, but performance testing has started with the first few hotspots identified and perhaps even addressed. No highest priority issues are in an open state. First-level developer documentation provided to help new developers with the learning curve.
 
-## alpha
+### alpha
 
 Feature complete, for all features committed to the production release. Ready for Proof of Concept-level deployments. Performance can be characterized in a predictable way, so that basic PoC's can be done within the bounds of published expectations. APIs are documented. First attempts at end-user documentation have been made. Developer documentation is further advanced. No highest priority issues are in an open state.
 
-## beta
+### beta
 
 Feature complete for all features committed to the production release, perhaps with optional features when safe to add. Ready for Pilot-level engagements. Performance is very well characterized and active optimizations are being done, with a target set for the Production release. No highest priority or high priority bugs are in an open state. Developer documentation is complete; end-user documentation is mostly done.
 
-## rcN
+### rcN
 
 For a forthcoming production release, we will prepare multiple candidate releases intended to be heavily tested by the community. As we cycle through resolving uncovered issues, we will issue another when no remaining highest or high priority issues remain, and repeat until we feel confident in releasing a production release, with no qualifier. e.g. 1.0.
+
+## Project Defined
+
+Projects may define their own release taxonomy, such as [CalVer](calver.org).  In order to use a custom taxonomy a project 
+
+* Must have a clearly defined and documented release taxonomy.  The documentation could be in their readme file or in their project wiki page.
+* Must have a policy covering forwards and backwards compatibility that is reflected by their taxonomy.
+* Should use the quality of release tags as defined in the [SemVer](#SemVer) release taxonomy in this policy.
+* Should not invent an entirely new taxonomy unrelated to other taxonomies (for example, arbitrary lists of characters from an animated film).
 
 [^1]: Note that this is **not** about exiting incubator status.
 


### PR DESCRIPTION
Allow projects to define their own taxonomy with some restrictions.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>